### PR TITLE
checks for type null before deferencing it

### DIFF
--- a/src/WebApiContrib.Formatting.MsgPack/MessagePackMediaTypeFormatter.cs
+++ b/src/WebApiContrib.Formatting.MsgPack/MessagePackMediaTypeFormatter.cs
@@ -18,9 +18,9 @@ namespace WebApiContrib.Formatting.MsgPack
     {
         private const string mediaType = "application/x-msgpack";
 
-        private static readonly Func<Type, bool> IsAllowedType = (t) =>
+        private static bool IsAllowedType(Type t)
         {
-            if (!t.IsAbstract && !t.IsInterface && t != null && !t.IsNotPublic)
+            if (t != null && !t.IsAbstract && !t.IsInterface && !t.IsNotPublic)
                 return true;
 
             if (typeof(IEnumerable).IsAssignableFrom(t))


### PR DESCRIPTION
The old code use accessed members of type before the check for null, which would result in a NullReferenceException. This change also removes the unnecessary `Func` object.
